### PR TITLE
Gives learn article list more space on mobile

### DIFF
--- a/static/css/tm.css
+++ b/static/css/tm.css
@@ -694,3 +694,12 @@ table.dataTable thead {
 }
 
 
+@media screen and (max-width: 700px) {
+  .flex-container.learn-list {
+    display: block;
+  }
+  
+  .image-container.learn-list {
+    margin: 0 auto;
+  }
+}


### PR DESCRIPTION
Moves thumbnail onto its own line, so article listing gets more screen real estate on mobile